### PR TITLE
fix: update Svelte components to use Svelte 5 syntax

### DIFF
--- a/src/lib/components/home/WorkSection.svelte
+++ b/src/lib/components/home/WorkSection.svelte
@@ -11,15 +11,15 @@
 		{ value: 'concepts', label: 'Concepts' }
 	];
 
-	function handleTabChange(event: CustomEvent<{ value: string }>) {
-		activeTab = event.detail.value;
+	function handleTabChange(detail: { value: string }) {
+		activeTab = detail.value;
 	}
 </script>
 
 <div class="space-y-6 sm:space-y-8 lg:space-y-12">
 	<PageHeading text="Work" />
 
-	<Tabs value={activeTab} {tabs} on:change={handleTabChange}>
+	<Tabs value={activeTab} {tabs} onchange={handleTabChange}>
 		{#if activeTab === 'projects'}
 			<ProjectList {projects} />
 		{:else if activeTab === 'concepts'}

--- a/src/lib/components/ui/Tabs.svelte
+++ b/src/lib/components/ui/Tabs.svelte
@@ -4,16 +4,15 @@
 -->
 
 <script lang="ts">
-	import { createEventDispatcher } from 'svelte';
-
-	export let value: string;
-	export let tabs: Array<{ value: string; label: string }>;
-
-	const dispatch = createEventDispatcher<{ change: { value: string } }>();
+	let { value, tabs, onchange }: { 
+		value: string; 
+		tabs: Array<{ value: string; label: string }>; 
+		onchange?: (detail: { value: string }) => void 
+	} = $props();
 
 	function handleTabClick(tabValue: string) {
 		value = tabValue;
-		dispatch('change', { value: tabValue });
+		onchange?.({ value: tabValue });
 	}
 </script>
 

--- a/src/lib/components/work/ProjectCarousel.svelte
+++ b/src/lib/components/work/ProjectCarousel.svelte
@@ -8,10 +8,12 @@
 	import { onMount } from 'svelte';
 	import OptimizedImage from '$lib/components/ui/OptimizedImage.svelte';
 
-	export let currentIndex: number = 0;
-	export let images: string[];
-	export let onImageClick: ((index: number) => void) | undefined = undefined;
-	export let title: string;
+	let { currentIndex = 0, images, onImageClick = undefined, title }: { 
+		currentIndex?: number; 
+		images: string[]; 
+		onImageClick?: ((index: number) => void) | undefined; 
+		title: string 
+	} = $props();
 
 	let carouselContainer: HTMLDivElement;
 	let currentSlide = currentIndex;

--- a/src/lib/components/work/ProjectDetails.svelte
+++ b/src/lib/components/work/ProjectDetails.svelte
@@ -5,9 +5,11 @@
 -->
 
 <script lang="ts">
-	export let title: string;
-	export let description: string;
-	export let link: string | undefined = undefined;
+	let { title, description, link = undefined }: { 
+		title: string; 
+		description: string; 
+		link?: string | undefined 
+	} = $props();
 </script>
 
 <article>

--- a/src/lib/components/work/ProjectList.svelte
+++ b/src/lib/components/work/ProjectList.svelte
@@ -11,7 +11,7 @@
 	import ProjectCarousel from './ProjectCarousel.svelte';
 	import OptimizedImage from '$lib/components/ui/OptimizedImage.svelte';
 
-	export let projects: ProjectInfo[];
+	let { projects }: { projects: ProjectInfo[] } = $props();
 
 	type OpenProjectImageOption = {
 		imageIndex: number;


### PR DESCRIPTION
Fixes #18

This PR resolves Svelte 5 deprecation warnings by updating component syntax to the modern patterns.

## Changes Made

- **Props Syntax**: Replaced deprecated `export let` with `$props()` syntax
- **Event Handling**: Replaced `createEventDispatcher` with callback props
- **Event Usage**: Updated event handling to use new callback pattern

These updates eliminate all Svelte 5 deprecation warnings in the component layer.

🤖 Generated with [Claude Code](https://claude.ai/code)