### PR TITLE
fix: convert wrangler.jsonc to wrangler.toml with nodejs_compat_v2

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,8 +1,0 @@
-{
-  "name": "personal",
-  "compatibility_date": "2025-09-11",
-  "compatibility_flags": ["nodejs_compat"],
-  "assets": {
-    "directory": "./build"
-  }
-}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,6 @@
+name = "personal"
+compatibility_date = "2025-09-11"
+compatibility_flags = ["nodejs_compat_v2"]
+
+[assets]
+directory = "./build"


### PR DESCRIPTION
Fixes issue #21

Converted wrangler configuration from jsonc to toml format and upgraded to nodejs_compat_v2 flag to resolve Node.js built-in module compatibility issues with nodemailer in Cloudflare Workers.

Generated with [Claude Code](https://claude.ai/code)