### PR TITLE
Fix Quality CI: Context dismiss timeout and actions/cache@v6

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -40,7 +40,7 @@ jobs:
         run: bun check
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('bun.lock') }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -40,7 +40,7 @@ jobs:
         run: bun check
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('bun.lock') }}

--- a/src/app-shell.browser.test.tsx
+++ b/src/app-shell.browser.test.tsx
@@ -1718,7 +1718,11 @@ describe("Mobile App Shell (App Shell seam)", () => {
     await expect.element(sheet.getByText(/^Stack$/i)).toBeVisible();
     await expect.element(sheet).toHaveTextContent(/sc-plus\.vercel\.app/i);
 
-    await screen.getByRole("button", { name: /dismiss overlay/i }).click();
+    // Sheet covers up to 62% from the bottom; click the dimmed region above it
+    // (Playwright's default center target sits under the sheet / Hire Signal).
+    await screen.getByRole("button", { name: /dismiss overlay/i }).click({
+      position: { x: Math.floor(MOBILE_VIEWPORT.width / 2), y: 40 },
+    });
     await expect.element(sheet).not.toBeInTheDocument();
 
     cleanup();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses all three Quality annotations from [run 30543090631](https://github.com/vishalkdotcom/personal/actions/runs/30543090631):

1. **Exit code 1** / **TimeoutError** on dismiss-overlay click — Playwright’s default center target lands under the Context bottom sheet (Hire Signal intercepts). Click the dimmed region above the sheet instead.
2. **Node.js 20 deprecation** — bump `actions/cache@v4` → `@v6` (latest major; Node 24 runtime).

## Verification

- `bun run test` — 207 passed (prior commit)
- Workflow change is a version pin only

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0b0d1b8-22d5-4fbe-a851-23c98d4d38fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0b0d1b8-22d5-4fbe-a851-23c98d4d38fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

